### PR TITLE
Refactor DraftlyWrapper to utilize custom hook for canvas event handling

### DIFF
--- a/src/entities/canvas/CanvasWrapper/index.tsx
+++ b/src/entities/canvas/CanvasWrapper/index.tsx
@@ -1,64 +1,26 @@
-import { useRef, forwardRef, useImperativeHandle, useCallback } from 'react';
-
-import type { EventOffset } from 'shared/types/canvas';
-
-import { Draftly } from '../classes/Draftly';
+import { forwardRef } from 'react';
 import styles from './style.module.scss';
+import { useCanvasWrapper } from './useCanvasWrapper';
+import { Draftly } from '../classes/Draftly';
 
-export const DraftlyWrapper = forwardRef<Draftly>(
-  (_, ref) => {
-    const canvasRef = useRef<HTMLCanvasElement | null>(null);
-    const draftlyRef = useRef<Draftly | null>(null);
+export const DraftlyWrapper = forwardRef<Draftly>((_, ref) => {
+  const {
+    setCanvasRef,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    handlePointerCancel,
+  } = useCanvasWrapper(ref);
 
-    const setCanvasRef = useCallback((node: HTMLCanvasElement | null) => {
-      canvasRef.current = node;
-
-      if (node && !draftlyRef.current) {
-        draftlyRef.current = new Draftly(node);
-      }
-    }, []);
-
-    const getPointerOffset = (e: React.PointerEvent<HTMLCanvasElement>): EventOffset => {
-      const bounding = canvasRef.current?.getBoundingClientRect();
-      
-      return {
-        offsetX: e.clientX - (bounding?.left ?? 0),
-        offsetY: e.clientY - (bounding?.top ?? 0),
-      };
-    };
-
-    const handlePointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
-      e.preventDefault();
-      draftlyRef.current?.handlePointerDown(getPointerOffset(e));
-      (e.target as HTMLCanvasElement).setPointerCapture(e.pointerId);
-    };
-
-    const handlePointerMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
-      e.preventDefault();
-      draftlyRef.current?.handlePointerMove(getPointerOffset(e));
-    };
-
-    const handlePointerEnd = (e: React.PointerEvent<HTMLCanvasElement>) => {
-      e.preventDefault();
-      draftlyRef.current?.handlePointerUp();
-      (e.target as HTMLCanvasElement).releasePointerCapture(e.pointerId);
-    };
-
-    const handlePointerUp = handlePointerEnd;
-    const handlePointerCancel = handlePointerEnd;
-
-    useImperativeHandle(ref, () => draftlyRef.current as Draftly, []);
-
-    return (
-      <div className={styles.canvasWrapper}>
-        <canvas
-          ref={setCanvasRef}
-          onPointerDown={handlePointerDown}
-          onPointerMove={handlePointerMove}
-          onPointerUp={handlePointerUp}
-          onPointerCancel={handlePointerCancel}
-        />
-      </div>
-    );
-  },
-); 
+  return (
+    <div className={styles.canvasWrapper}>
+      <canvas
+        ref={setCanvasRef}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+      />
+    </div>
+  );
+}); 

--- a/src/entities/canvas/CanvasWrapper/useCanvasWrapper.ts
+++ b/src/entities/canvas/CanvasWrapper/useCanvasWrapper.ts
@@ -1,0 +1,52 @@
+import { useRef, useImperativeHandle, useCallback } from 'react';
+
+import type { EventOffset } from 'shared/types/canvas';
+
+import { Draftly } from '../classes/Draftly';
+
+export const useCanvasWrapper = (ref: React.Ref<Draftly>) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const draftlyRef = useRef<Draftly | null>(null);
+
+  const setCanvasRef = useCallback((node: HTMLCanvasElement | null) => {
+    canvasRef.current = node;
+    if (node && !draftlyRef.current) {
+      draftlyRef.current = new Draftly(node);
+    }
+  }, []);
+
+  const getPointerOffset = (e: React.PointerEvent<HTMLCanvasElement>): EventOffset => {
+    const bounding = canvasRef.current?.getBoundingClientRect();
+    return {
+      offsetX: e.clientX - (bounding?.left ?? 0),
+      offsetY: e.clientY - (bounding?.top ?? 0),
+    };
+  };
+
+  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    e.preventDefault();
+    draftlyRef.current?.handlePointerDown(getPointerOffset(e));
+    (e.target as HTMLCanvasElement).setPointerCapture(e.pointerId);
+  }, []);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    e.preventDefault();
+    draftlyRef.current?.handlePointerMove(getPointerOffset(e));
+  }, []);
+
+  const handlePointerEnd = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    e.preventDefault();
+    draftlyRef.current?.handlePointerUp();
+    (e.target as HTMLCanvasElement).releasePointerCapture(e.pointerId);
+  }, []);
+
+  useImperativeHandle(ref, () => draftlyRef.current as Draftly, []);
+
+  return {
+    setCanvasRef,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp: handlePointerEnd,
+    handlePointerCancel: handlePointerEnd,
+  };
+}; 

--- a/src/entities/canvas/CanvasWrapper/useCanvasWrapper.ts
+++ b/src/entities/canvas/CanvasWrapper/useCanvasWrapper.ts
@@ -1,4 +1,4 @@
-import { useRef, useImperativeHandle, useCallback } from 'react';
+import { useRef, useImperativeHandle, useCallback, type PointerEvent } from 'react';
 
 import type { EventOffset } from 'shared/types/canvas';
 
@@ -15,7 +15,7 @@ export const useCanvasWrapper = (ref: React.Ref<Draftly>) => {
     }
   }, []);
 
-  const getPointerOffset = (e: React.PointerEvent<HTMLCanvasElement>): EventOffset => {
+  const getPointerOffset = (e: PointerEvent<HTMLCanvasElement>): EventOffset => {
     const bounding = canvasRef.current?.getBoundingClientRect();
     return {
       offsetX: e.clientX - (bounding?.left ?? 0),
@@ -23,18 +23,18 @@ export const useCanvasWrapper = (ref: React.Ref<Draftly>) => {
     };
   };
 
-  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+  const handlePointerDown = useCallback((e: PointerEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     draftlyRef.current?.handlePointerDown(getPointerOffset(e));
     (e.target as HTMLCanvasElement).setPointerCapture(e.pointerId);
   }, []);
 
-  const handlePointerMove = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+  const handlePointerMove = useCallback((e: PointerEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     draftlyRef.current?.handlePointerMove(getPointerOffset(e));
   }, []);
 
-  const handlePointerEnd = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+  const handlePointerEnd = useCallback((e: PointerEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     draftlyRef.current?.handlePointerUp();
     (e.target as HTMLCanvasElement).releasePointerCapture(e.pointerId);


### PR DESCRIPTION
* Simplified the DraftlyWrapper component by extracting pointer event handling logic into a custom hook, useCanvasWrapper. This enhances code clarity and maintainability while preserving existing functionality.